### PR TITLE
Feat/batch consume events

### DIFF
--- a/batch-service/src/main/java/com/example/command/batch/publish_event/create/CreateAllTransactionEventBatchConfiguration.java
+++ b/batch-service/src/main/java/com/example/command/batch/publish_event/create/CreateAllTransactionEventBatchConfiguration.java
@@ -87,7 +87,7 @@ public class CreateAllTransactionEventBatchConfiguration {
         kafkaItemWriter.setKafkaTemplate(kafkaTemplate);
         kafkaItemWriter.setItemKeyMapper(EventItemRecord::getPartitionKey);
         kafkaItemWriter.setTopic(KafkaProperties.CREATE_TRANSACTION_TOPIC);
-        kafkaItemWriter.setTimeout(3000);
+        kafkaItemWriter.setTimeout(1500);
         return kafkaItemWriter;
     }
 }

--- a/search-service/src/main/java/com/example/query/kafka/CustomKafkaConsumer.java
+++ b/search-service/src/main/java/com/example/query/kafka/CustomKafkaConsumer.java
@@ -1,44 +1,64 @@
 package com.example.query.kafka;
 
-import com.example.query.adapter.ApartmentTransactionAdapter;
+import com.example.query.adapter.document.ApartmentTransaction;
 import com.example.query.kafka.record.CreateTransactionRecord;
 import com.example.query.kafka.record.EventRecord;
 import com.example.query.kafka.record.UpdateTransactionRecord;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.Pair;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class CustomKafkaConsumer {
 
-    private final ObjectMapper objectMapper;
-    private final ApartmentTransactionAdapter apartmentTransactionAdapter;
+    private final MongoTemplate mongoTemplate;
+    private final ForkJoinPool kafkaForkJoinPool;
 
-    @KafkaListener(topics = CustomKafkaProperties.CREATE_TRANSACTION_TOPIC, groupId = "query-service", containerFactory = "kafkaListenerContainerFactory")
-    public void consumeCreateTransactionEvent(@Payload String message) throws JsonProcessingException {
-        CreateTransactionRecord createTransactionRecord = convertToEventRecord(message, CreateTransactionRecord.class);
-        if (apartmentTransactionAdapter.isExistTransaction(createTransactionRecord.id())) {
-            return;
+    public CustomKafkaConsumer(MongoTemplate mongoTemplate, @Qualifier(value = "kafkaForkJoinPool") ForkJoinPool kafkaForkJoinPool) {
+        this.mongoTemplate = mongoTemplate;
+        this.kafkaForkJoinPool = kafkaForkJoinPool;
+    }
+
+
+    @KafkaListener(topics = CustomKafkaProperties.CREATE_TRANSACTION_TOPIC, groupId = "query-service", containerFactory = "batchKafkaListenerContainerFactoryForCreateEvent")
+    public void consumeCreateTransactionEvent(@Payload List<CreateTransactionRecord> messages)  {
+
+        List<Pair<Query, Update>> pairs = kafkaForkJoinPool.submit(() ->
+                messages.parallelStream()
+                        .map(EventRecord::toQueryUpdate)
+                        .toList()
+        ).join();
+
+        mongoTemplate.bulkOps(BulkOperations.BulkMode.ORDERED, ApartmentTransaction.class)
+                .upsert(pairs)
+                .execute();
+    }
+
+    @KafkaListener(topics = CustomKafkaProperties.UPDATE_TRANSACTION_TOPIC, groupId = "query-service", containerFactory = "batchKafkaListenerContainerFactoryForUpdateEvent")
+    public void consumeUpdateTransactionEvent(@Payload List<UpdateTransactionRecord> messages)  {
+        List<Pair<Query, Update>> pairs = kafkaForkJoinPool.submit(() ->
+                messages.parallelStream()
+                        .map(EventRecord::toQueryUpdate)
+                        .toList()
+        ).join();
+
+        BulkOperations bulkOperations = mongoTemplate.bulkOps(BulkOperations.BulkMode.ORDERED, ApartmentTransaction.class);
+
+        for (Pair<Query, Update> pair : pairs) {
+            bulkOperations.updateOne(pair.getFirst(), pair.getSecond());
         }
-        apartmentTransactionAdapter.save(createTransactionRecord.toEntity());
 
-    }
-
-    @KafkaListener(topics = CustomKafkaProperties.UPDATE_TRANSACTION_TOPIC, groupId = "query-service", containerFactory = "kafkaListenerContainerFactory")
-    public void consumeUpdateTransactionEvent(@Payload String message) throws JsonProcessingException {
-        log.info("consumeUpdateTransactionEvent message: {}", message);
-        UpdateTransactionRecord updateTransactionRecord = convertToEventRecord(message, UpdateTransactionRecord.class);
-        apartmentTransactionAdapter.updatePredictCost(updateTransactionRecord.id(), updateTransactionRecord.predictCost(), updateTransactionRecord.isReliable());
-    }
-
-    public <T extends EventRecord> T convertToEventRecord(String message, Class<T> clazz) throws JsonProcessingException {
-        return objectMapper.readValue(message, clazz);
+        bulkOperations.execute();
     }
 }

--- a/search-service/src/main/java/com/example/query/kafka/KafkaConsumerConfiguration.java
+++ b/search-service/src/main/java/com/example/query/kafka/KafkaConsumerConfiguration.java
@@ -1,54 +1,77 @@
 package com.example.query.kafka;
 
+import com.example.query.kafka.record.CreateTransactionRecord;
+import com.example.query.kafka.record.EventRecord;
+import com.example.query.kafka.record.UpdateTransactionRecord;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ForkJoinPool;
 
 @EnableKafka
 @RequiredArgsConstructor
 @EnableConfigurationProperties(CustomKafkaProperties.class)
 @Profile("!test")
+@Configuration
 public class KafkaConsumerConfiguration {
 
     private final CustomKafkaProperties kafkaProperties;
 
-    @Bean
-    public ConsumerFactory<Long, String> consumerFactory() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");  // 가장 처음부터 읽기
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "query-service");
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1000);
-        properties.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 10000);
-        properties.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);
-        //session timeout
-        properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 9000);
-        properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 3000);
-        return new DefaultKafkaConsumerFactory<>(properties);
+    @Bean(name = "kafkaForkJoinPool")
+    public ForkJoinPool kafkaForkJoinPool() {
+        return new ForkJoinPool(7);
     }
 
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<Long, String> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<Long, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    @Bean(name = "batchKafkaListenerContainerFactoryForCreateEvent")
+    public ConcurrentKafkaListenerContainerFactory<Long, CreateTransactionRecord> batchKafkaListenerContainerFactoryForCreateEvent() {
+        ConcurrentKafkaListenerContainerFactory<Long, CreateTransactionRecord> factory = new ConcurrentKafkaListenerContainerFactory<>();
         ContainerProperties containerProperties = factory.getContainerProperties();
-        containerProperties.setIdleBetweenPolls(3000);
-        factory.setConsumerFactory(consumerFactory());
+        containerProperties.setIdleBetweenPolls(500);
+
+        factory.setConsumerFactory(consumerFactory(CreateTransactionRecord.class));
+        factory.setBatchListener(true);
         factory.setConcurrency(1);
         return factory;
+    }
+
+    @Bean(name = "batchKafkaListenerContainerFactoryForUpdateEvent")
+    public ConcurrentKafkaListenerContainerFactory<Long, UpdateTransactionRecord> batchKafkaListenerContainerFactoryForUpdateEvent() {
+        ConcurrentKafkaListenerContainerFactory<Long, UpdateTransactionRecord> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        ContainerProperties containerProperties = factory.getContainerProperties();
+        containerProperties.setIdleBetweenPolls(500);
+
+        factory.setBatchListener(true);
+        factory.setConsumerFactory(consumerFactory(UpdateTransactionRecord.class));
+        factory.setConcurrency(1);
+        return factory;
+    }
+
+    private <T extends EventRecord> ConsumerFactory<Long, T> consumerFactory(Class<T> eventRecordClass) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaProperties.getBootstrapServers());
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "query-service");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1000);
+        properties.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 200000);
+        properties.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);
+        properties.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 9000);
+        properties.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 3000);
+        properties.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1024 * 1024);
+        properties.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 1000);
+        return new DefaultKafkaConsumerFactory<>(properties, new LongDeserializer(), new JsonDeserializer<>(eventRecordClass, false));
     }
 
 }

--- a/search-service/src/main/java/com/example/query/kafka/UpdateTransactionRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/UpdateTransactionRecord.java
@@ -1,4 +1,0 @@
-package com.example.query.kafka;
-
-public record UpdateTransactionRecord(long id, long predictCost, boolean isReliable) {
-}

--- a/search-service/src/main/java/com/example/query/kafka/record/CreateTransactionRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/CreateTransactionRecord.java
@@ -1,8 +1,13 @@
 package com.example.query.kafka.record;
 
 import com.example.query.adapter.document.ApartmentTransaction;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.Pair;
 
 import java.time.LocalDate;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
 
 public record CreateTransactionRecord(long id, String apartmentName, int buildYear, int dealAmount,
                                       double areaForExclusiveUse, String jibun, int floor, LocalDate dealDate, String dealingGbn,

--- a/search-service/src/main/java/com/example/query/kafka/record/CreateTransactionRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/CreateTransactionRecord.java
@@ -33,4 +33,28 @@ public record CreateTransactionRecord(long id, String apartmentName, int buildYe
     public Long getPartitionKey() {
         return id;
     }
+
+    @Override
+    public Pair<Query, Update> toQueryUpdate() {
+        Query query = new Query();
+        query.addCriteria(where("transactionId").is(id));
+
+        Update update = new Update();
+        update.set("apartmentName", apartmentName);
+        update.set("buildYear", buildYear);
+        update.set("dealAmount", dealAmount);
+        update.set("areaForExclusiveUse", areaForExclusiveUse);
+        update.set("jibun", jibun);
+        update.set("floor", floor);
+        update.set("dealDate", dealDate);
+        update.set("dealingGbn", dealingGbn);
+        update.set("latitude", latitude);
+        update.set("longitude", longitude);
+        update.set("gu", gu);
+        update.set("dong", dong);
+        update.set("predictedCost", predictedCost);
+        update.set("isReliable", isReliable);
+
+        return Pair.of(query, update);
+    }
 }

--- a/search-service/src/main/java/com/example/query/kafka/record/EventRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/EventRecord.java
@@ -2,4 +2,5 @@ package com.example.query.kafka.record;
 
 public interface EventRecord {
     Long getPartitionKey();
+    Pair<Query, Update> toQueryUpdate();
 }

--- a/search-service/src/main/java/com/example/query/kafka/record/EventRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/EventRecord.java
@@ -1,5 +1,9 @@
 package com.example.query.kafka.record;
 
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.Pair;
+
 public interface EventRecord {
     Long getPartitionKey();
     Pair<Query, Update> toQueryUpdate();

--- a/search-service/src/main/java/com/example/query/kafka/record/UpdateTransactionRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/UpdateTransactionRecord.java
@@ -5,4 +5,16 @@ public record UpdateTransactionRecord(long id, long predictCost, boolean isRelia
     public Long getPartitionKey() {
         return id;
     }
+
+    @Override
+    public Pair<Query, Update> toQueryUpdate() {
+        Query query = new Query();
+        query.addCriteria(where("transactionId").is(id));
+
+        Update update = new Update();
+        update.set("predictedCost", predictCost);
+        update.set("isReliable", isReliable);
+
+        return Pair.of(query, update);
+    }
 }

--- a/search-service/src/main/java/com/example/query/kafka/record/UpdateTransactionRecord.java
+++ b/search-service/src/main/java/com/example/query/kafka/record/UpdateTransactionRecord.java
@@ -1,5 +1,11 @@
 package com.example.query.kafka.record;
 
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.util.Pair;
+
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
 public record UpdateTransactionRecord(long id, long predictCost, boolean isReliable) implements EventRecord {
     @Override
     public Long getPartitionKey() {


### PR DESCRIPTION
BatchListner로 변경
Batch로 얻은 Records를 ForkJoinPool을 이용하여 병렬적으로 수행(CPU 작업이므로 ForkJoinPool 사용)
최종적으로 130만 개 데이터 Consume 소요 시간 50분 -> 19분으로 대폭 감소